### PR TITLE
Canada Bank Transfer: Use payment name as reference instead of payment ID

### DIFF
--- a/canada_bank_transfer/generate_eft.py
+++ b/canada_bank_transfer/generate_eft.py
@@ -201,6 +201,8 @@ def _format_destinator_name(destinator_name: str) -> str:
 
 
 def _format_transaction_reference(reference: str) -> str:
+    if len(reference) > 19:
+        reference = reference[-19:]
     reference_sanitized = _remove_accents_and_special_caracters(reference)
     return _justify_left_with_blanks(reference_sanitized.upper(), 19)
 
@@ -296,7 +298,7 @@ def _format_credit_detail_segment(payment: Payment) -> str:
             destinator_name=_format_destinator_name(payment.partner_id.name),
             user_long_name=_format_user_long_name(payment.journal_id.company_id.name),
             user_number=payment.journal_id.eft_user_number,
-            transaction_reference=_format_transaction_reference(str(payment.id)),
+            transaction_reference=_format_transaction_reference(payment.name),
             origin_institution=origin_account.bank_id.canada_institution,
             origin_transit=origin_account.canada_transit,
             origin_account=_format_account_number(origin_account.acc_number),

--- a/canada_bank_transfer/tests/test_generate_eft.py
+++ b/canada_bank_transfer/tests/test_generate_eft.py
@@ -242,11 +242,17 @@ class TestEFTCreditDetails(EFTCase):
 
     def test_transaction_reference_number(self):
         record = format_credit_details_group(self.journal, self.payments, 1, 2)
-        reference = record[174:193]
-        assert int(reference) == self.pmt_1.id
+        reference = record[174:192]
+        assert reference == self.pmt_1.name.replace('/', '_')
 
-        reference_2 = record[174 + 240:193 + 240]
-        assert int(reference_2) == self.pmt_2.id
+        reference_2 = record[174 + 240:192 + 240]
+        assert reference_2 == self.pmt_2.name.replace('/', '_')
+
+    def test_transaction_reference_number_with_long_payment_name(self):
+        self.pmt_1.name = 'SUPP.OUT/2019/1234567'
+        record = format_credit_details_group(self.journal, self.payments, 1, 2)
+        reference = record[174:193]
+        assert reference == 'PP.OUT_2019_1234567'
 
     def test_origin_institution(self):
         record = format_credit_details_group(self.journal, self.payments, 1, 2)


### PR DESCRIPTION
https://isidor.numigi.net/web#id=9587&view_type=form&model=project.task&menu_id=