### PR TITLE
Fix message_post in account_move_chatter

### DIFF
--- a/account_move_chatter/log_account_move_reversal.py
+++ b/account_move_chatter/log_account_move_reversal.py
@@ -13,5 +13,5 @@ class AccountMoveWithLogReversal(models.Model):
     @api.multi
     def _reverse_move(self, *args, **kwargs):
         result = super()._reverse_move(*args, **kwargs)
-        self.message_post(_(MOVE_REVERSAL_MESSAGE))
+        self.message_post(body=_(MOVE_REVERSAL_MESSAGE))
         return result


### PR DESCRIPTION
The method message_post should not be called with positional arguments because
it may or may not fail depending on the installed modules.