### PR TITLE
TA#37674 use creation date of stripe transaction

### DIFF
--- a/bank_statement_online_stripe/README.rst
+++ b/bank_statement_online_stripe/README.rst
@@ -77,12 +77,11 @@ Known Issues
 
 Payment Date
 ~~~~~~~~~~~~
-Note that a payment in ``Stripe`` takes a few days before becoming available in the balance.
+Note that the module uses the creation date of a balance transaction instead of
+its date of availability in order to determine whether a transaction should be imported or not.
 
-Only transactions that are available in the balance are imported into Odoo.
-
-The date in the Odoo Statement is the date when the payment becomes available,
-not the date when the payment is created.
+This means that the balance shown in the bank statement in Odoo does not reflect
+the amount available for a payout in Stripe.
 
 Contributors
 ------------

--- a/bank_statement_online_stripe/interface.py
+++ b/bank_statement_online_stripe/interface.py
@@ -24,10 +24,10 @@ class BalanceTransactionInterface:
 
     def _get_balance_at(self, timestamp):
         current_balance = self._get_current_balance()
-        available_on = {
+        created = {
             "gte": timestamp,
         }
-        transactions = self._iter_transactions(available_on=available_on)
+        transactions = self._iter_transactions(created=created)
         balance = current_balance - sum(
             t.get("amount", 0) - t.get("fee", 0) for t in transactions
         )
@@ -36,39 +36,37 @@ class BalanceTransactionInterface:
     def _get_current_balance(self):
         payload = stripe.Balance.retrieve(api_key=self._api_key)
         balance = next(
-            (b for b in payload["available"] if b["currency"] == self._currency)
+            (b for b in payload["pending"] if b["currency"] == self._currency)
         )
         return balance["amount"]
 
     def list_transactions(self):
-        available_on = {
+        created = {
             "gte": self._timestamp_from,
             "lt": self._timestamp_to,
         }
-        return [t for t in self._iter_transactions(available_on=available_on)]
+        return [t for t in self._iter_transactions(created=created)]
 
-    def _iter_transactions(self, available_on):
-        for items in self._walk_transaction_batches(available_on):
+    def _iter_transactions(self, created):
+        for items in self._walk_transaction_batches(created):
             yield from iter(items)
 
-    def _walk_transaction_batches(self, available_on, starting_after=None):
+    def _walk_transaction_batches(self, created, starting_after=None):
         payload = stripe.BalanceTransaction.list(
-            available_on=available_on,
+            created=created,
             limit=TRANSACTION_BATCH_LIMIT,
             currency=self._currency,
             api_key=self._api_key,
             starting_after=starting_after,
             expand=["data.source.billing_details"],
         )
-        items = [
-            t for t in payload["data"] if t.get("status") == "available"
-        ]
+        items = payload["data"]
         yield items
 
         if payload["has_more"]:
             last_item_id = items[-1]["id"]
             yield from self._walk_transaction_batches(
-                available_on=available_on, starting_after=last_item_id
+                created=created, starting_after=last_item_id
             )
 
     @staticmethod

--- a/bank_statement_online_stripe/models/online_bank_statement_provider.py
+++ b/bank_statement_online_stripe/models/online_bank_statement_provider.py
@@ -141,7 +141,7 @@ class OnlineBankStatementProvider(models.Model):
         return source.get("billing_details") or {}
 
     def _get_stripe_transaction_date(self, tx):
-        timestamp = tx["available_on"]
+        timestamp = tx["created"]
         datetime_ = datetime.fromtimestamp(timestamp)
         return fields.Date.context_today(self, datetime_)
 

--- a/bank_statement_online_stripe/tests/test_interface.py
+++ b/bank_statement_online_stripe/tests/test_interface.py
@@ -68,13 +68,6 @@ class TestStripeTransactionInterface(common.TransactionCase):
 
         assert balance == 100 - 10 - 20 - 30
 
-    def test_test_end_balance__exclude_pending_transactions(self):
-        self.t3["status"] = "pending"
-        with self._mock_balance_transaction_list(), self._mock_balance():
-            balance = self.interface.get_end_balance()
-
-        assert balance == 100 - 10 - 20
-
     @contextmanager
     def _mock_balance_transaction_list(self):
         side_effect = [
@@ -88,7 +81,7 @@ class TestStripeTransactionInterface(common.TransactionCase):
     def _mock_balance(self):
         return_value = {
             "object": "balance",
-            "available": [
+            "pending": [
                 {
                     "amount": self.balance,
                     "currency": "cad",

--- a/bank_statement_online_stripe/tests/test_online_bank_statement_provider.py
+++ b/bank_statement_online_stripe/tests/test_online_bank_statement_provider.py
@@ -57,7 +57,7 @@ class TestStripe(common.SavepointCase):
         self.transaction_id = "txn_1"
         self.transaction = {
             "id": self.transaction_id,
-            "available_on": int(self.datetime_from.timestamp()),
+            "created": int(self.datetime_from.timestamp()),
             "object": "balance_transaction",
             "description": self.reference,
             "amount": 1000,
@@ -157,24 +157,24 @@ class TestStripe(common.SavepointCase):
 
     @contextmanager
     def _mock_balance_transaction_list(self):
-        def side_effect(available_on, **kwargs):
+        def side_effect(created, **kwargs):
             return {
                 "has_more": False,
-                "data": self._get_filtered_transactions(available_on),
+                "data": self._get_filtered_transactions(created),
             }
 
         with patch("stripe.BalanceTransaction.list", side_effect=side_effect):
             yield
 
-    def _get_filtered_transactions(self, available_on):
+    def _get_filtered_transactions(self, created):
         transactions = self.transactions
 
-        gte = available_on.get("gte")
+        gte = created.get("gte")
         if gte:
-            transactions = [t for t in transactions if gte <= t["available_on"]]
-        lt = available_on.get("lt")
+            transactions = [t for t in transactions if gte <= t["created"]]
+        lt = created.get("lt")
         if lt:
-            transactions = [t for t in transactions if t["available_on"] < lt]
+            transactions = [t for t in transactions if t["created"] < lt]
 
         return transactions
 
@@ -182,7 +182,7 @@ class TestStripe(common.SavepointCase):
     def _mock_balance(self, amount):
         return_value = {
             "object": "balance",
-            "available": [
+            "pending": [
                 {
                     "amount": amount,
                     "currency": "cad",


### PR DESCRIPTION
Instead of availability date.

The reason is that using the availability date of a transaction
ended up in a lot of confusion for the user.

The drawback now is that the statement does not reflect the
balance available for a payout.