### PR TITLE
TA#41362 fix module account_analytic_required_forbidden

### DIFF
--- a/account_analytic_required_forbidden/i18n/fr.po
+++ b/account_analytic_required_forbidden/i18n/fr.po
@@ -1,19 +1,21 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-#	* account_analytic_required_forbidden
+# 	* account_analytic_required_forbidden
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-12 14:35+0000\n"
-"PO-Revision-Date: 2019-03-12 14:35+0000\n"
+"POT-Creation-Date: 2021-12-21 19:10+0000\n"
+"PO-Revision-Date: 2021-12-21 14:11-0500\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
+"X-Generator: Poedit 2.3\n"
 
 #. module: account_analytic_required_forbidden
 #: model:ir.model,name:account_analytic_required_forbidden.model_account_account
@@ -31,8 +33,22 @@ msgid "Analytic Account Required"
 msgstr "Compte analytique obligatoire"
 
 #. module: account_analytic_required_forbidden
+#: model:ir.model.fields,field_description:account_analytic_required_forbidden.field_account_account__display_name
+#: model:ir.model.fields,field_description:account_analytic_required_forbidden.field_account_move__display_name
+#: model:ir.model.fields,field_description:account_analytic_required_forbidden.field_account_move_line__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: account_analytic_required_forbidden
+#: model:ir.model.fields,field_description:account_analytic_required_forbidden.field_account_account__id
+#: model:ir.model.fields,field_description:account_analytic_required_forbidden.field_account_move__id
+#: model:ir.model.fields,field_description:account_analytic_required_forbidden.field_account_move_line__id
+msgid "ID"
+msgstr ""
+
+#. module: account_analytic_required_forbidden
 #: model:ir.model,name:account_analytic_required_forbidden.model_account_move
-msgid "Journal Entries"
+msgid "Journal Entry"
 msgstr ""
 
 #. module: account_analytic_required_forbidden
@@ -41,17 +57,41 @@ msgid "Journal Item"
 msgstr ""
 
 #. module: account_analytic_required_forbidden
-#: code:addons/account_analytic_required_forbidden/models.py:36
-#, python-format
-msgid "The journal entry can not be posted because the line {line} "
-"has an analytic account ({analytic_account}). "
-"The account {account} forbids an analytic account."
-msgstr "La pièce comptable ne peut pas être validée, car la ligne {line} a un compte analytique ({analytic_account}). "
-"Le compte {account} ne permet pas d’inscrire un compte analytique."
+#: model:ir.model.fields,field_description:account_analytic_required_forbidden.field_account_account____last_update
+#: model:ir.model.fields,field_description:account_analytic_required_forbidden.field_account_move____last_update
+#: model:ir.model.fields,field_description:account_analytic_required_forbidden.field_account_move_line____last_update
+msgid "Last Modified on"
+msgstr ""
 
 #. module: account_analytic_required_forbidden
-#: code:addons/account_analytic_required_forbidden/models.py:27
+#: code:addons/account_analytic_required_forbidden/models.py:0
 #, python-format
-msgid "The journal entry can not be posted because the line {line} has no analytic account. The account {account} requires an analytic account."
-msgstr "La pièce comptable ne peut pas être validée, car la ligne {line} "
-"n’a pas de compte analytique. Le compte {account} oblige de renseigner le compte analytique."
+msgid ""
+"The analytic account can not be required and forbidden for the same GL "
+"account ({})."
+msgstr ""
+"Le compte analytique ne peut pas être obligatoire et interdit pour le même "
+"compte de GL ({})."
+
+#. module: account_analytic_required_forbidden
+#: code:addons/account_analytic_required_forbidden/models.py:0
+#, python-format
+msgid ""
+"The journal entry can not be posted because the line {line} has an analytic "
+"account ({analytic_account}). The account {account} forbids an analytic "
+"account."
+msgstr ""
+"La pièce comptable ne peut pas être validée, car la ligne {line} a un compte "
+"analytique ({analytic_account}). Le compte {account} ne permet pas "
+"d’inscrire un compte analytique."
+
+#. module: account_analytic_required_forbidden
+#: code:addons/account_analytic_required_forbidden/models.py:0
+#, python-format
+msgid ""
+"The journal entry can not be posted because the line {line} has no analytic "
+"account. The account {account} requires an analytic account."
+msgstr ""
+"La pièce comptable ne peut pas être validée, car la ligne {line} n’a pas de "
+"compte analytique. Le compte {account} oblige de renseigner le compte "
+"analytique."

--- a/account_analytic_required_forbidden/models.py
+++ b/account_analytic_required_forbidden/models.py
@@ -7,51 +7,66 @@ from odoo.exceptions import ValidationError
 
 class Account(models.Model):
 
-    _inherit = 'account.account'
+    _inherit = "account.account"
 
     analytic_account_required = fields.Boolean()
     analytic_account_forbidden = fields.Boolean()
 
+    @api.constrains("analytic_account_required", "analytic_account_forbidden")
+    def _check_analytic_account_required_forbidden(self):
+        for account in self:
+            if account.analytic_account_required and account.analytic_account_forbidden:
+                raise ValidationError(
+                    _(
+                        "The analytic account can not be required and forbidden "
+                        "for the same GL account ({})."
+                    ).format(self.display_name)
+                )
 
-def _format_account_move_line(move_line: 'AccountMoveLine') -> str:
+
+def _format_account_move_line(move_line: "AccountMoveLine") -> str:
     """Format an account move line for displaying in a message error."""
     return "{} - {}".format(move_line.account_id.code, move_line.name)
 
 
 class AccountMoveLine(models.Model):
 
-    _inherit = 'account.move.line'
+    _inherit = "account.move.line"
 
     def _check_analytic_account_required_or_forbidden(self):
         if not self.analytic_account_id and self.account_id.analytic_account_required:
-            raise ValidationError(_(
-                'The journal entry can not be posted because the line {line} '
-                'has no analytic account. The account {account} requires an analytic account.'
-            ).format(
-                line=_format_account_move_line(self),
-                account=self.account_id.display_name,
-            ))
+            raise ValidationError(
+                _(
+                    "The journal entry can not be posted because the line {line} "
+                    "has no analytic account. The account {account} requires an analytic account."
+                ).format(
+                    line=_format_account_move_line(self),
+                    account=self.account_id.display_name,
+                )
+            )
 
         if self.analytic_account_id and self.account_id.analytic_account_forbidden:
-            raise ValidationError(_(
-                'The journal entry can not be posted because the line {line} '
-                'has an analytic account ({analytic_account}). '
-                'The account {account} forbids an analytic account.'
-            ).format(
-                line=_format_account_move_line(self),
-                account=self.account_id.display_name,
-                analytic_account=self.analytic_account_id.display_name,
-            ))
+            raise ValidationError(
+                _(
+                    "The journal entry can not be posted because the line {line} "
+                    "has an analytic account ({analytic_account}). "
+                    "The account {account} forbids an analytic account."
+                ).format(
+                    line=_format_account_move_line(self),
+                    account=self.account_id.display_name,
+                    analytic_account=self.analytic_account_id.display_name,
+                )
+            )
 
 
 class AccountMove(models.Model):
 
-    _inherit = 'account.move'
+    _inherit = "account.move"
 
     def _check_analytic_account_required_or_forbidden(self):
-        for line in self.mapped('line_ids'):
+        for line in self.mapped("line_ids"):
             line._check_analytic_account_required_or_forbidden()
 
-    def post(self, *args, **kwargs):
+    def _post(self, *args, **kwargs):
         self._check_analytic_account_required_or_forbidden()
-        return super().post(*args, **kwargs)
+        return super()._post(*args, **kwargs)

--- a/account_analytic_required_forbidden/tests/test_account_move.py
+++ b/account_analytic_required_forbidden/tests/test_account_move.py
@@ -65,3 +65,8 @@ class TestAccountMove(common.SavepointCase):
         self.line_2.analytic_account_id = self.analytic
         with pytest.raises(ValidationError):
             self.move.post()
+
+    def test_both_fields_checked(self):
+        self.account_1.analytic_account_required = True
+        with pytest.raises(ValidationError):
+            self.account_1.analytic_account_forbidden = True


### PR DESCRIPTION
The method post of account.move is deprecated.
It is replaced with _post.