### PR TITLE
TA#72372 [12.0][UPD] circleCI to remove codacy test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,9 +25,9 @@ jobs:
           name: Run Test
           command: docker-compose run --rm odoo run_pytest.sh
 
-       - run:
-          name: Codacy Coverage
-          command: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -l python -r .log/coverage.xml
+       # - run:
+       #     name: Codacy Coverage
+       #     command: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -l python -r .log/coverage.xml
 
        - store_test_results:
           path: .log


### PR DESCRIPTION
## Summary
- Comment out Codacy coverage lines in CircleCI configuration
- Remove dependency on Codacy service for coverage reporting

## Test plan
- Verify CircleCI pipeline runs without Codacy coverage step
- Confirm all other tests continue to work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)